### PR TITLE
Add the Azure Boards badge to the README updated 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/liangzhu/f7e7bd47-4b82-4bdd-9cea-e703dded2058/5ed9d96c-7f2f-41fa-a07b-f1d06af5ea53/_apis/work/boardbadge/ea01f3e9-6a2e-4d14-b5b8-4bdab52ba974)](https://codedev.ms/liangzhu/f7e7bd47-4b82-4bdd-9cea-e703dded2058/_boards/board/t/5ed9d96c-7f2f-41fa-a07b-f1d06af5ea53/Microsoft.RequirementCategory)
 # bottest


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#27](https://codedev.ms/liangzhu/f7e7bd47-4b82-4bdd-9cea-e703dded2058/_workitems/edit/27)